### PR TITLE
Refactor: mover lógica de filtros a FilterHelper y unificar acceso a $_GET con RequestHelper

### DIFF
--- a/app/config/routes.php
+++ b/app/config/routes.php
@@ -5,7 +5,7 @@ return [
         'action' => 'index'
     ],
     'newsletter/subscribe' => [
-        'controller' => 'Newsletter\\SubscribeController',
+        'controller' => 'Newsletter\SubscribeController',
         'action' => 'index'
     ]
 ];

--- a/app/controllers/Home/IndexController.php
+++ b/app/controllers/Home/IndexController.php
@@ -1,8 +1,47 @@
 <?php
+
+/*
+1. app\controllers\Home\IndexController.php
+Podria refactorizar estas lineas:
+
+$search = $_GET['search'] ?? '';
+$filter = $_GET['filter'] ?? null;
+$sort = $_GET['sort'] ?? null;
+$category = $_GET['category'] ?? null;
+
+2. app\core\Router.php
+Podria refactorizar estas lineas:
+$url = $_GET['url'] ?? '';
+
+Metiendolo en una clase y metodos donde podamos llamar ese metodo y no tener esas 4 lineas si no una que invoque al metodo, 
+claro siempre y cuando se instancie la clase que contiene dicho meotdo
+
+---------------------------------------------------------------------------------------------------------------------------------------------
+
+app\controllers\Newsletter\SubscribeController.php
+Podemos meter en validaciones (app\helpers\ValidationHelper.php) estas lineas de codigo:
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    ...
+} else {
+    // si alguien accede directamente por GET
+    http_response_code(405);
+    echo "Metodo no permitido";
+}
+
+if (empty($email) || !filter_var($email, FILTER_VALIDATE_EMAIL))
+
+---------------------------------------------------------------------------------------------------------------------------------------------
+app\controllers\Product\ListController.php
+Al parecer esto ya no se esta usando en el proyecto ya que se sustituyo por el home controller.
+Debo pedir ayudar a chatgpt para confirmar.
+*/
+
 namespace Controllers\Home;
 
 use Core\Controller;
 use Models\Product\ProductRepository;
+use App\Helpers\RequestHelper;
 
 class IndexController extends Controller
 {
@@ -11,10 +50,17 @@ class IndexController extends Controller
         $db = $this->loadDB();
         $repo = new ProductRepository($db);
 
-        $search = $_GET['search'] ?? '';
-        $filter = $_GET['filter'] ?? null;
-        $sort = $_GET['sort'] ?? null;
-        $category = $_GET['category'] ?? null;
+        $params = RequestHelper::getQueryParams([
+            'search' => '', 
+            'filter' => null, 
+            'sort' => null, 
+            'category' => null
+        ]);
+
+        $search = $params['search'];
+        $filter = $params['filter'];
+        $sort = $params['sort'];
+        $category = $params['category'];
 
         $currentPage = isset($_GET['page']) && is_numeric($_GET['page']) ? (int) $_GET['page'] : 1;
         $productsPerPage = 8;

--- a/app/core/Autoloader.php
+++ b/app/core/Autoloader.php
@@ -10,17 +10,18 @@ class Autoloader
 
     public static function autoload($class)
     {
-        // Reemplazar namespace por ruta relativa
+        // Elimina el namespace raíz "App\" para resolver la ruta relativa desde /app
+        if (strpos($class, 'App\\') === 0) {
+            $class = substr($class, 4); // Remueve 'App\' del namespace
+        }
+
         $class = str_replace('\\', DIRECTORY_SEPARATOR, $class);
+        $file = dirname(__DIR__) . DIRECTORY_SEPARATOR . $class . '.php';
 
-        // Asumimos que todas las clases estan dentro de la carpeta /app
-        $file = __DIR__ . '/../' . $class . '.php';
-
-        if(file_exists($file)) {
+        if (file_exists($file)) {
             require_once $file;
         } else {
-            // Opcional: lanzar excepcion para facilitar debug
-            throw new \Exception("No se pudo cargar la clase: $class");
+            throw new \Exception("No se pudo cargar la clase: $class (ruta: $file)");
         }
     }
 }

--- a/app/core/Router.php
+++ b/app/core/Router.php
@@ -3,17 +3,14 @@
 
 namespace Core;
 
+use App\Helpers\RequestHelper;
+
 class Router
 {
     public function handleRequest()
     {
-
-        // Cargar rutas personalizadas
-        $customRoutes = require_once __DIR__ . '/../config/routes.php';
-
         // Obtener URI limpia
         $requestUri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-
         $scriptName = dirname($_SERVER['SCRIPT_NAME']);
 
         // Elimionar el path base (/anime-shop/public)
@@ -23,7 +20,11 @@ class Router
 
         $url = trim($requestUri, '/');
 
-        // Verificar si hay ruta personalizada
+        // -------------------------
+        // 📌 Rutas Personalizadas
+        // -------------------------
+        $customRoutes = require_once __DIR__ . '/../config/routes.php';
+
         if (isset($customRoutes[$url])) {
             $route = $customRoutes[$url];
             $controllerClass = 'Controllers\\' . $route['controller'];
@@ -47,8 +48,11 @@ class Router
         }
 
 
-        // Obtener la URL limpia
-        $url = $_GET['url'] ?? '';
+        // -------------------------
+        // 📌 Rutas Dinámicas convencionales (/controlador/accion)
+        // -------------------------
+        // $url = $_GET['url'] ?? '';
+        $url = RequestHelper::getQueryParam('url', '');
         $url = trim($url, '/');
         $segments = $url !== '' ? explode('/', $url) : [];
 
@@ -71,7 +75,6 @@ class Router
                 throw new \Exception("Controlador $controllerClass no encontrado");
             }
         } catch(\Exception $e) {
-            // Puedes crear un ErrorController para manejar esto
             http_response_code(404);
             echo "Error: " .$e->getMessage();
         }

--- a/app/helpers/FilterHelper.php
+++ b/app/helpers/FilterHelper.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Helpers;
+
+class FilterHelper
+{
+    /**
+     * Verifica si un filtro está activo basado en los query params.
+     * @param array $queryParams Array con parámetros de consulta (usualmente $_GET)
+     * @param string $filterName Nombre del filtro a verificar
+     * @param string $filterValue Valor del filtro para comparar
+     * @return bool
+     */
+
+    public static function isActiveFilter(array $queryParams, string $filterName, string $filterValue  ): bool
+    {
+        return isset($queryParams[$filterName]) && $queryParams[$filterName] === $filterValue;
+    }
+
+    /**
+     * Verifica si no hay ningún filtro activo en los query params.
+     * @param array $queryParams Array con parámetros de consulta (usualmente $_GET)
+     * @param array $filters Lista de filtros a verificar
+     * @return bool
+     */
+    public static function isAllActive(array $queryParams, array $filters): bool
+    {
+        foreach ($filters as $filterName) {
+            if (isset($queryParams[$filterName]) && $queryParams[$filterName] !== '') {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/app/helpers/RequestHelper.php
+++ b/app/helpers/RequestHelper.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Helpers;
+
+class RequestHelper
+{
+    /**
+     * Obtener un solo parámetro del query string ($_GET)
+     *
+     * @param string $key     Clave del parámetro
+     * @param mixed  $default Valor por defecto si no está presente
+     * @return mixed
+     */
+    public static function getQueryParam(string $key, $default = null) {
+        return $_GET[$key] ?? $default;
+    }
+
+    public static function getQueryParams(array $keysWithDefaults): array
+    {
+        $result = [];
+        foreach ($keysWithDefaults as $key => $default) {
+            $result[$key] = $_GET[$key] ?? $default;
+        }
+        return $result;
+    }
+}

--- a/app/models/product/ProductRepository.php
+++ b/app/models/product/ProductRepository.php
@@ -77,8 +77,6 @@ class ProductRepository
         $params[':offset'] = (int)$offset;
 
         return $this->productModel->executeQuery($sql, $params);
-
-        // return $this    ->productModel->getFilteredPaginated($filter, $sort, $category, $limit, $offset, $search);
     }
 
     public function countFilteredProducts($filter, $category, $search)

--- a/app/view/components/_navbar_secondary.php
+++ b/app/view/components/_navbar_secondary.php
@@ -1,42 +1,44 @@
 <!-- Filtros superiores -->
 <?php
 
+use App\Helpers\FilterHelper;
+use App\Helpers\RequestHelper;
+
+/*
+app\view\components\_navbar_secondary.php
+Las funciones:
+* isActiveFilter
+* isAllActive
+
+Se deben meter en otro lado. Mi propuesta es que deben ser helpers en esta ruta estan app\helpers.
+Auque tambien tengo en esta ruta app\helpers\ValidationHelper.php helpers
+¿En cual de los dos deberia de meterlo?
+
+SE METIO EN LA RUTA app\helpers Y SE CREO EL ARCHIVO LLAMADO FilterHelper
+TAMBIEN SE TUVO QUE MODIFICAR EL CODIGO DEL AUTOLOAD DEL METODO autoload para que agarrara el namespace de los filteR, 
+YA QUE ESTABA LEYENDO SOLO DEDSDE CORE
+*/
+
+
 $query = $_GET;
 
-// Para los filters top o filtros superiores
-$currentFilter = $_GET['filter'] ?? null;
-$currentSort = $_GET['sort'] ?? null;
-$currentCategory = $_GET['category'] ?? null;
-
-    function isActiveFilter(array $queryParams, $type, $value) {
-    return (isset($queryParams[$type]) && $queryParams[$type] === $value) ? 'active-filter' : '';
-}
-
-    function isAllActive(array $queryParams) {
-    $filter = $queryParams['filter'] ?? null;
-    $sort = $queryParams['sort'] ?? null;
-    $category = $queryParams['category'] ?? null;
-
-    $hasRealFilters = !empty($filter) || !empty($sort) || !empty($category);
-    return !$hasRealFilters ? 'active-filter' : '';
-}
 ?>
 <nav class="navbar-secondary">
     <ul class="ul-secondary">
         <li>
-            <a class="<?= isAllActive($query) ?>" href="../public/catalog">Todos</a>
+            <a class="<?= FilterHelper::isAllActive($query, ['filter', 'sort', 'category']) ? 'active-filter' : '' ?>" href="../public/catalog">Todos</a>
         </li>
         <li>
-            <a class="<?= isActiveFilter($query, 'filter', 'in-stock') ?>" href="../public/catalog?filter=in-stock">Disponibles</a>
+            <a class="<?= FilterHelper::isActiveFilter($query, 'filter', 'in-stock') ? 'active-filter' : '' ?>" href="../public/catalog?filter=in-stock">Disponibles</a>
         </li>
         <li>
-            <a class="<?= isActiveFilter($query, 'filter', 'discounted') ?>" href="../public/catalog?filter=discounted">En oferta</a>
+            <a class="<?= FilterHelper::isActiveFilter($query, 'filter', 'discounted') ? 'active-filter' : '' ?>" href="../public/catalog?filter=discounted">En oferta</a>
         </li>
         <li>
-            <a class="<?= isActiveFilter($query, 'sort', 'newest') ?>" href="../public/catalog?sort=newest">Novedades</a>
+            <a class="<?= FilterHelper::isActiveFilter($query, 'sort', 'newest') ? 'active-filter' : '' ?>" href="../public/catalog?sort=newest">Novedades</a>
         </li>
         <li>
-            <a class="<?= isActiveFilter($query, 'sort', 'top-sellers') ?>" href="../public/catalog?sort=top-sellers">Mas vendidos</a>
+            <a class="<?= FilterHelper::isActiveFilter($query, 'sort', 'top-sellers') ? 'active-filter' : '' ?>" href="../public/catalog?sort=top-sellers">Mas vendidos</a>
         </li>
     </ul>
 </nav>


### PR DESCRIPTION
### Cambios realizados

- Se movieron las funciones `isActiveFilter()` e `isAllActive()` desde las vistas a una nueva clase helper llamada `FilterHelper`.
  - Ubicación: `app\helpers\FilterHelper.php`
  - Estas funciones ahora son métodos estáticos: `FilterHelper::isActiveFilter(...)` y `FilterHelper::isAllActive(...)`.

- Se creó un nuevo helper `RequestHelper` para centralizar el acceso a los parámetros de consulta (`$_GET`).
  - Métodos añadidos:
    - `RequestHelper::getQueryParam($key, $default = null)`
    - `RequestHelper::getQueryParams(array $keys)`
  - Se aplicó el refactor en:
    - `Home\IndexController`
    - `_navbar_secondary.php`
    - `Router.php`

### Motivación

Este cambio busca mejorar:
- La separación de responsabilidades (vista vs lógica).
- La mantenibilidad del código.
- La consistencia en el acceso a datos de entrada (`$_GET`).
- La posibilidad de testear los métodos de filtro y request.

---

**Este refactor ya fue probado y validado en local.**
