### PR TITLE
Sección de pedidos de usuario completa con listado, detalle y fechas formateadas

### DIFF
--- a/app/controllers/User/OrderDetailController.php
+++ b/app/controllers/User/OrderDetailController.php
@@ -1,0 +1,50 @@
+<?php
+namespace Controllers\User;
+
+use Core\Controller;
+use Models\Order\OrderRepository;
+use Models\Order\OrderModel;
+use App\Helpers\SessionHelper;
+
+class OrderDetailController extends Controller
+{
+    private OrderRepository $orderRepository;
+    private $db;
+
+    public function __construct()
+    {
+        $this->db = $this->loadDB();
+        $orderModel = new OrderModel($this->db);
+        $this->orderRepository = new OrderRepository($orderModel);
+    }
+
+    public function index()
+    {
+        $dataUser = SessionHelper::getUser();
+        if (!$dataUser || empty($dataUser['user_id'])) {
+            header('Location: /anime-shop/public/user/login');
+            exit;
+        }
+
+        $orderId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+        if ($orderId < 1) {
+            header('Location: /anime-shop/public/user/orders');
+            exit;
+        }
+
+        $order = $this->orderRepository->getOrderWithItems($orderId);
+
+        // Validación: el pedido pertenece al usuario
+        if (!$order || $order['user_id'] !== $dataUser['user_id']) {
+            header('Location: /anime-shop/public/user/orders');
+            exit;
+        }
+
+        $content = __DIR__ . '/../../view/user/orderDetail.php';
+        $title = "Detalle de pedido #{$order['order_id']}";
+        $pageName = 'order-detail';
+        $assets = ['orderDetail', 'cart'];
+
+        include __DIR__ . '/../../view/layouts/base.php';
+    }
+}

--- a/app/controllers/User/OrdersController.php
+++ b/app/controllers/User/OrdersController.php
@@ -27,11 +27,20 @@ class OrdersController extends Controller
             exit;
         }
 
-        $orders = $this->orderRepository->getUserOrders($dataUser['user_id'], 6);
+        // Parámetros de paginación
+        $perPage = 6; 
+        $currentPage = isset($_GET['page']) && is_numeric($_GET['page']) ? (int) $_GET['page'] : 1;
+        if ($currentPage < 1) $currentPage = 1;
+        $offset = ($currentPage - 1) * $perPage;
+
+        // Obtener pedidos y total
+        $orders = $this->orderRepository->getUserOrders($dataUser['user_id'], $perPage, $offset);
+        $totalOrders = $this->orderRepository->countUserOrders($dataUser['user_id']);
+        $totalPages = (int) ceil($totalOrders / $perPage);
 
         $content = __DIR__ . '/../../view/user/orders.php';
         $title = 'Mis pedidos';
-        $page = 'orders';
+        $pageName = 'orders';
 
         $assets = ['orders', 'cart'];
 

--- a/app/helpers/DateHelper.php
+++ b/app/helpers/DateHelper.php
@@ -1,0 +1,70 @@
+<?php
+
+/* ejemplos de implementacion */
+/*
+<?= \App\helpers\DateHelper::formatShort($order['created_at']); ?>
+<?= \App\helpers\DateHelper::formatLong($order['created_at']); ?>
+<?= \App\helpers\DateHelper::formatRelative($order['created_at']); ?>
+*/
+/* ejemplos de implementacion */
+
+namespace App\helpers;
+
+class DateHelper
+{
+    /**
+     * Convierte una fecha de MySQL en formato corto: dd/mm/yyyy hh:mm
+     */
+    public static function formatShort(string $dateTime): string
+    {
+        $date = new \DateTime($dateTime);
+        return $date->format('d/m/Y H:i');
+    }
+
+    /**
+     * Convierte una fecha de MySQL en formato largo: 11 de septiembre de 2025, 17:40 hrs
+     */
+    public static function formatLong(string $dateTime): string
+    {
+        $date = new \DateTime($dateTime);
+
+        $formatter = new \IntlDateFormatter(
+            'es_ES',                       // Idioma y región
+            \IntlDateFormatter::LONG,      // Fecha larga
+            \IntlDateFormatter::SHORT,     // Hora corta
+            $date->getTimezone(),          // Respeta la zona horaria del objeto DateTime
+            \IntlDateFormatter::GREGORIAN  // Calendario gregoriano
+        );
+
+        // Devuelve algo como: "11 de septiembre de 2025, 17:40"
+        return $formatter->format($date);
+    }
+
+    /**
+     * Convierte una fecha de MySQL en formato relativo: "hace 2 horas", "ayer", "hace 3 días"
+     */
+    public static function formatRelative(string $dateTime): string
+    {
+        $now = new \DateTime();
+        $date = new \DateTime($dateTime);
+        $diff = $now->diff($date);
+
+        if ($diff->y > 0) {
+            return $diff->y === 1 ? 'hace 1 año' : "hace {$diff->y} años";
+        }
+        if ($diff->m > 0) {
+            return $diff->m === 1 ? 'hace 1 mes' : "hace {$diff->m} meses";
+        }
+        if ($diff->d > 0) {
+            if ($diff->d === 1) return 'ayer';
+            return "hace {$diff->d} días";
+        }
+        if ($diff->h > 0) {
+            return $diff->h === 1 ? 'hace 1 hora' : "hace {$diff->h} horas";
+        }
+        if ($diff->i > 0) {
+            return $diff->i === 1 ? 'hace 1 minuto' : "hace {$diff->i} minutos";
+        }
+        return 'justo ahora';
+    }
+}

--- a/app/helpers/OrderHelper.php
+++ b/app/helpers/OrderHelper.php
@@ -1,0 +1,54 @@
+<?php
+namespace App\Helpers;
+
+class OrderHelper
+{
+    /**
+     * Retorna un texto amigable para el estado de la orden
+     * @param string $status
+     * @return string
+     */
+    public static function getStatusText(string $status): string
+    {
+        return match ($status) {
+            'cancelled' => 'Productos (Pedido cancelado)',
+            'rejected'  => 'Productos (Pedido rechazado)',
+            'pending'   => 'Productos (Pendiente de pago)',
+            default     => 'Productos comprados',
+        };
+    }
+
+    /**
+     * Devuelve la dirección de envío completa en un formato amigable
+     * @param array $order
+     * @return string
+     */
+    public static function getFullShippingAddress(array $order): string
+    {
+        $parts = [];
+
+        if (!empty($order['fullname'])) {
+            $parts[] = htmlspecialchars($order['fullname']);
+        }
+        if (!empty($order['street'])) {
+            $parts[] = htmlspecialchars($order['street']);
+        }
+        if (!empty($order['neighborhood'])) {
+            $parts[] = htmlspecialchars($order['neighborhood']);
+        }
+        if (!empty($order['city'])) {
+            $parts[] = htmlspecialchars($order['city']);
+        }
+        if (!empty($order['state'])) {
+            $parts[] = htmlspecialchars($order['state']);
+        }
+        if (!empty($order['postal_code'])) {
+            $parts[] = htmlspecialchars($order['postal_code']);
+        }
+        if (!empty($order['country'])) {
+            $parts[] = htmlspecialchars($order['country']);
+        }
+
+        return implode(', ', $parts);
+    }
+}

--- a/app/models/Order/OrderModel.php
+++ b/app/models/Order/OrderModel.php
@@ -48,7 +48,15 @@ class OrderModel
 
     public function getOrderById(int $orderId): ?array
     {
-        $stmt = $this->db->prepare("SELECT * FROM orders WHERE order_id = :order_id");
+        $stmt = $this->db->prepare("
+            SELECT o.*, u.name AS user_name, u.email AS user_email, sa.address_id, sa.fullname, 
+            sa.email AS sa_email, sa.phone AS sa_phone, sa.street, sa.neighborhood, sa.postal_code, 
+            sa.city, sa.state, sa.country  
+            FROM orders o
+            INNER JOIN users u ON o.user_id = u.user_id 
+            INNER JOIN shipping_addresses sa ON sa.address_id = o.shipping_address_id
+            WHERE o.order_id = :order_id
+        ");
         $stmt->bindValue(':order_id', $orderId, PDO::PARAM_INT);
         $stmt->execute();
         $order = $stmt->fetch(PDO::FETCH_ASSOC);
@@ -61,7 +69,7 @@ class OrderModel
         $stmt = $this->db->prepare("
             SELECT oi.product_id, oi.quantity, oi.price, p.name, p.image, p.stock
             FROM order_items oi
-            JOIN products p ON oi.product_id = p.product_id
+            INNER JOIN products p ON oi.product_id = p.product_id
             WHERE oi.order_id = :order_id
         ");
         $stmt->bindValue(':order_id', $orderId, PDO::PARAM_INT);
@@ -112,15 +120,27 @@ class OrderModel
         return (int) ($result['total'] ?? 0);
     }
 
-    public function getOrdersByUser(int $userId, int $limit = 5): array
+    public function countOrdersByUser(int $userId): int
+    {
+        $sql = "SELECT COUNT(*) as total FROM orders WHERE user_id = :user_id";
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+        $stmt->execute();
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return (int) ($result['total'] ?? 0);
+    }
+
+    public function getOrdersByUser(int $userId, int $limit = 5, int $offset = 0): array
     {
         $sql = "SELECT * FROM orders 
                 WHERE user_id = :user_id 
                 ORDER BY created_at DESC 
-                LIMIT :limit";
+                LIMIT :limit OFFSET :offset";
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
         $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
         $stmt->execute();
 
         return $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/app/models/Order/OrderRepository.php
+++ b/app/models/Order/OrderRepository.php
@@ -61,9 +61,14 @@ class OrderRepository
         return $this->model->countPendingOrders();
     }
 
-    public function getUserOrders(int $userId, int $limit = 5): array
+    public function getUserOrders(int $userId, int $limit = 5, int $offset = 0): array
     {
-        return $this->model->getOrdersByUser($userId, $limit);
+        return $this->model->getOrdersByUser($userId, $limit, $offset);
+    }
+
+    public function countUserOrders(int $userId): int
+    {
+        return $this->model->countOrdersByUser($userId);
     }
 
 }

--- a/app/view/layouts/base.php
+++ b/app/view/layouts/base.php
@@ -50,6 +50,10 @@
         <link rel="stylesheet" href="/anime-shop/public/assets/css/components/orders.css">
     <?php endif; ?>
 
+    <?php if (in_array('orderDetail', $assets)): ?>
+        <link rel="stylesheet" href="/anime-shop/public/assets/css/components/detail-order.css">
+    <?php endif; ?>
+
     <?php if (in_array('errors', $assets)): ?>
         <link rel="stylesheet" href="/anime-shop/public/assets/css/components/errors.css">
     <?php endif; ?>

--- a/app/view/user/account.php
+++ b/app/view/user/account.php
@@ -47,7 +47,7 @@
                         <?php foreach ($orders as $order): ?>
                             <tr>
                                 <td data-label="ID Pedido">#<?= htmlspecialchars($order['order_id']) ?></td>
-                                <td data-label="Fecha"><?= htmlspecialchars($order['created_at']) ?></td>
+                                <td data-label="Fecha"><?= htmlspecialchars(\App\helpers\DateHelper::formatShort($order['created_at'])) ?></td>
                                 <td data-label="Estado"><?= htmlspecialchars($order['status']) ?></td>
                                 <td data-label="Total">$<?= number_format($order['total'], 2) ?></td>
                                 <td data-label="Acción">

--- a/app/view/user/orderDetail.php
+++ b/app/view/user/orderDetail.php
@@ -1,0 +1,52 @@
+<div class="account-page">
+    <section class="orders-section order-detail">
+        <h1>Detalle del pedido #<?= htmlspecialchars($order['order_id']) ?></h1>
+
+        <div class="order-info">
+            <p><strong>Fecha:</strong> <?= htmlspecialchars(\App\helpers\DateHelper::formatLong($order['created_at'])) ?></p>
+            <p><strong>Estado:</strong> <?= htmlspecialchars($order['status']) ?></p>
+            <p><strong>Total:</strong> $<?= number_format($order['total'], 2) ?></p>
+            <p><strong>Dirección de envío:</strong> <?= \App\Helpers\OrderHelper::getFullShippingAddress($order); ?></p>
+        </div>
+
+        <h2><?= \App\Helpers\OrderHelper::getStatusText($order['status']); ?></h2>
+
+        <table class="orders-table">
+            <thead>
+                <tr>
+                    <th>Imagen</th>
+                    <th>Producto</th>
+                    <th>Cantidad</th>
+                    <th>Precio Unitario</th>
+                    <th>Subtotal</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($order['items'] as $item): ?>
+                <tr>
+                    <td data-label="Imagen">
+                        <a href="/anime-shop/public/product/detail?product_id=<?= $item['product_id'] ?>&product_name=<?= urlencode($item['name']) ?>" title="Ir al detalle del producto">
+                            <img src="/anime-shop/public/assets/images/products/<?= htmlspecialchars($item['image']) ?>" alt="<?= htmlspecialchars($item['name']) ?>" class="product-img">
+                        </a>
+                    </td>
+                    <td data-label="Producto">
+                        <a href="/anime-shop/public/product/detail?product_id=<?= $item['product_id'] ?>&product_name=<?= urlencode($item['name']) ?>" class="product-link" title="Ir al detalle del producto">
+                            <?= htmlspecialchars($item['name']) ?>
+                        </a>
+                    </td>
+                    <td data-label="Cantidad"><?= $item['quantity'] ?></td>
+                    <td data-label="Precio">$<?= number_format($item['price'], 2) ?></td>
+                    <td data-label="Subtotal">$<?= number_format($item['price'] * $item['quantity'], 2) ?></td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+
+        <a href="/anime-shop/public/user/orders" class="btn-primary back-orders">Volver a mis pedidos</a>
+
+        <?php if (in_array('cart', $assets)): ?>
+            <script async src="/anime-shop/public/assets/js/components/cart.js" type="module"></script>
+        <?php endif; ?>
+
+    </section>
+</div>

--- a/app/view/user/orders.php
+++ b/app/view/user/orders.php
@@ -19,7 +19,7 @@
                         <?php foreach ($orders as $order): ?>
                             <tr>
                                 <td data-label="ID Pedido">#<?= htmlspecialchars($order['order_id']) ?></td>
-                                <td data-label="Fecha"><?= htmlspecialchars($order['created_at']) ?></td>
+                                <td data-label="Fecha"><?= htmlspecialchars(\App\helpers\DateHelper::formatShort($order['created_at'])) ?></td>
                                 <td data-label="Estado"><?= htmlspecialchars($order['status']) ?></td>
                                 <td data-label="Total">$<?= number_format($order['total'], 2) ?></td>
                                 <td data-label="Acción">
@@ -32,6 +32,48 @@
                         <?php endforeach; ?>
                     </tbody>
                 </table>
+
+                <?php if ($totalPages > 1): ?>
+                <aside class="aside-paginated">
+                    <ul class="page-list">
+
+                        <?php
+                        // Parámetros persistentes (si quieres mantener filtros o búsqueda en futuro)
+                        $extraParams = '';
+                        if (!empty($_GET)) {
+                            $queryParams = $_GET;
+                            unset($queryParams['page']);
+                            $extraParams = '&' . http_build_query($queryParams);
+                        }
+                        ?>
+
+                        <!-- Anterior -->
+                        <?php if ($currentPage > 1): ?>
+                            <li>
+                                <a href="?page=<?= $currentPage - 1 . $extraParams; ?>" class="page-previous"></a>
+                            </li>
+                        <?php endif; ?>
+
+                        <!-- Números de página -->
+                        <?php for ($i = 1; $i <= $totalPages; $i++): ?>
+                            <?php if ($i == $currentPage): ?>
+                                <li><a href="?page=<?= $i . $extraParams; ?>" class="page-current"><?= $i; ?></a></li>
+                            <?php else: ?>
+                                <li><a href="?page=<?= $i . $extraParams; ?>" class="page-number"><?= $i; ?></a></li>
+                            <?php endif; ?>
+                        <?php endfor; ?>
+
+                        <!-- Siguiente -->
+                        <?php if ($currentPage < $totalPages): ?>
+                            <li>
+                                <a href="?page=<?= $currentPage + 1 . $extraParams; ?>" class="page-next"></a>
+                            </li>
+                        <?php endif; ?>
+
+                    </ul>
+                </aside>
+                <?php endif; ?>
+
             <?php else: ?>
                 <p>Aún no tienes pedidos registrados.</p>
             <?php endif; ?>

--- a/public/assets/css/components/detail-order.css
+++ b/public/assets/css/components/detail-order.css
@@ -1,0 +1,83 @@
+.order-detail {
+    display: flex;
+    flex-direction: column;
+    padding: 1rem;
+}
+
+.order-detail h1 {
+    color: var(--primary-color);
+}
+
+.order-info p {
+    margin: 0.5rem 0;
+}
+
+.orders-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+
+.orders-table tbody tr:hover {
+    background-color: rgba(1, 90, 148, 0.1); /* color sutil según tu tema */
+}
+
+.orders-table th,
+.orders-table td {
+    border: 1px solid #ddd;
+    padding: 0.5rem;
+    text-align: left;
+}
+
+.product-img {
+    width: 60px;      /* aumenta un poco el tamaño si es necesario */
+    height: 60px;
+    object-fit: contain; /* evita recortes, mantiene proporción */
+    border-radius: 4px;
+}
+
+/* Alinea el botón al final de la sección en desktop */
+.back-orders {
+    margin-top: 1rem;
+    align-self: flex-end;   /* lo lleva a la derecha */
+    display: inline-block;  /* se ajusta al contenido */
+    text-align: center;
+    padding: 0.5rem 1rem;
+    transition: background 0.3s;
+}
+
+.back-orders:hover {
+    background-color: var(--accent-color);
+    color: #fff;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .orders-table thead {
+        display: none;
+    }
+
+    .orders-table tr {
+        display: block;
+        margin-bottom: 1rem;
+        border-bottom: 1px solid #ccc;
+    }
+
+    .orders-table td {
+        display: flex;
+        justify-content: space-between;
+        padding: 0.5rem 0;
+    }
+
+    .orders-table td[data-label]:before {
+        content: attr(data-label);
+        font-weight: bold;
+    }
+
+    /* Responsive: ocupar todo el ancho en móviles */
+    .back-orders {
+        align-self: stretch; /* ocupa todo el ancho */
+        width: 100%;
+        margin: 0.5rem 0;
+    }
+}

--- a/public/assets/css/components/orders.css
+++ b/public/assets/css/components/orders.css
@@ -64,6 +64,78 @@
     padding: 0.5rem;
 }
 
+/* Paginacion */
+/* Contenedor principal del paginado */
+.aside-paginated {
+    grid-column: 1 / -1; /* ocupa todas las columnas del grid padre */
+    margin-top: 1.5rem;
+}
+
+.page-list {
+    display: grid;
+    grid-template-columns: repeat(7, auto);
+    gap: 0.5rem;
+    justify-content: center;
+    padding: 1rem;
+    list-style: none;
+    margin: 0;
+}
+
+.page-list li a {
+    padding: 0.5rem 0.7rem;
+    color: #333;
+    cursor: unset;
+    border-radius: 4px;
+    transition: all 0.3s ease;
+}
+
+.page-list li a.page-current {
+    background-color: var(--secondary-color);
+    color: #fff;
+}
+
+.page-list li a.page-number,
+.page-list li a.page-previous,
+.page-list li a.page-next {
+    transition: color 0.3s ease;
+}
+
+.page-list li a.page-number:hover,
+.page-list li a.page-previous:hover,
+.page-list li a.page-next:hover {
+    color: var(--accent-color);
+    cursor: pointer;
+}
+
+/* Solo las flechas */
+.page-list li a.page-previous::before {
+    content: '«';
+}
+
+.page-list li a.page-next::after {
+    content: '»';
+}
+
+/* Remueve estilos por defecto de enlaces */
+a {
+    text-decoration: none;
+    color: inherit;
+}
+
+a:visited {
+    color: inherit;
+}
+
+a:hover,
+a:focus {
+    text-decoration: none;
+    color: inherit;
+}
+
+a:active {
+    color: inherit;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     .orders-table thead {
@@ -111,5 +183,50 @@
 
     .orders-section h1 {
         font-size: var(--font-size-paragraph);
+    }
+}
+
+/* Responsive paginacion */
+/* Responsive para paginado */
+@media (max-width: 768px) {
+    .page-list {
+        grid-template-columns: repeat(5, auto);
+        gap: 0.4rem;
+        padding: 0.8rem;
+    }
+
+    .page-list li a {
+        padding: 0.4rem 0.6rem;
+        font-size: 0.9rem;
+    }
+}
+
+/* ================= Responsive Paginado ================= */
+
+/* Tablets */
+@media (max-width: 768px) {
+    .page-list {
+        grid-template-columns: repeat(5, auto);
+        gap: 0.4rem;
+        padding: 0.8rem;
+    }
+
+    .page-list li a {
+        padding: 0.4rem 0.6rem;
+        font-size: 0.9rem;
+    }
+}
+
+/* Móviles */
+@media (max-width: 480px) {
+    .page-list {
+        grid-template-columns: repeat(3, auto);
+        gap: 0.3rem;
+        padding: 0.5rem;
+    }
+
+    .page-list li a {
+        padding: 0.3rem 0.5rem;
+        font-size: 0.8rem;
     }
 }


### PR DESCRIPTION
Se implementa la sección de pedidos para usuarios registrados en Anime Shop:

1. Vista "Mi cuenta" → sección "Mis pedidos" (5 más recientes, fechas cortas con DateHelper::formatShort).
2. Vista "Mis pedidos" → listado completo con paginación, fechas cortas (DateHelper::formatShort).
3. Vista "Detalle del pedido" → detalle completo, fechas largas (DateHelper::formatLong), enlace a detalle de productos.
4. Mejora de diseño general y responsive, especialmente para móviles.
5. Backend totalmente estructurado con MVC + Repository y validaciones.