### PR TITLE
Gestión de roles y superadministrador en Anime Shop

### DIFF
--- a/app/controllers/User/RegisterController.php
+++ b/app/controllers/User/RegisterController.php
@@ -30,7 +30,7 @@ class RegisterController extends Controller
             'email' => $_POST['email'],
             'password' => $_POST['password'], 
             'confirm_password' => $_POST['confirm_password'], 
-            'role' => $_POST['role']
+            'role' => 'customer'
         ];
 
         $errors = [];
@@ -55,9 +55,6 @@ class RegisterController extends Controller
         else if ($error = ValidationHelper::matchPasswords($data['password'], $data['confirm_password']))
             $errors['confirm_password'] = $error;
 
-        if ($error = ValidationHelper::required('rol', $data['role']))
-            $errors['role'] = $error;
-
         if (!empty($errors)) {
             ResponseHelper::jsonResponse([
                 'success' => false, 
@@ -73,7 +70,7 @@ class RegisterController extends Controller
             'name' => $data['name'], 
             'email' => $data['email'], 
             'password' => $data['password'], 
-            'role' => $_POST['role']
+            'role' => 'customer'
         ];
 
         if ($userRepo->emailExists($userData['email'])) {
@@ -84,7 +81,7 @@ class RegisterController extends Controller
         }
 
         // Registro con asignación de rol "customer"
-        $result = $userRepo->registerWithRole($userData, $userData['role']);
+        $result = $userRepo->registerWithRole($userData, 'customer');
 
         if ($result['success']) {
             ResponseHelper::jsonResponse([

--- a/app/helpers/ValidationHelper.php
+++ b/app/helpers/ValidationHelper.php
@@ -23,7 +23,7 @@ class ValidationHelper
 
     public static function required(string $fieldName, ?string $value): ?string
     {
-        return empty(StringHelper::trim($value)) ? "El campo $fieldName es obligatorio PHP." : null ;
+        return empty(StringHelper::trim($value)) ? "El campo $fieldName es obligatorio." : null ;
     }
 
     public static function validateName(?string $value): ?string
@@ -31,11 +31,11 @@ class ValidationHelper
         $value = StringHelper::trim($value);
 
         if (strlen($value) < 3) {
-            return "El nombre debe tener al menos 3 caracteres PHP.";
+            return "El nombre debe tener al menos 3 caracteres.";
         }
 
         if (!preg_match('/^[\p{L}\s]+$/u', $value)) {
-            return "El nombre solo puede contener letras y espacios PHP.";
+            return "El nombre solo puede contener letras y espacios.";
         }
 
         return null;
@@ -45,7 +45,7 @@ class ValidationHelper
     {
         $value = StringHelper::trim($value);
 
-        return filter_var($value, FILTER_VALIDATE_EMAIL) ? null : "El correo no es válido PHP." ;
+        return filter_var($value, FILTER_VALIDATE_EMAIL) ? null : "El correo no es válido." ;
     }
 
     public static function validatePasswordStrength(?string $value): ?string
@@ -53,11 +53,11 @@ class ValidationHelper
         $value = StringHelper::trim($value);
 
         if (strlen($value) < 8) {
-            return "La contraseña debe tener al menos 8 caracteres PHP.";
+            return "La contraseña debe tener al menos 8 caracteres.";
         }
 
         if (!preg_match('/[A-Za-z]/', $value) || !preg_match('/\d/', $value)) {
-            return "La contraseña debe contener letras y números PHP.";
+            return "La contraseña debe contener letras y números.";
         }
 
         return null;
@@ -144,7 +144,7 @@ class ValidationHelper
         $value = StringHelper::trim($value);
 
         if (!preg_match('/^\d{10,15}$/', $value)) {
-            return "El teléfono debe tener entre 10 y 15 dígitos PHP.";
+            return "El teléfono debe tener entre 10 y 15 dígitos.";
         }
 
         return null;

--- a/app/middleware/AdminMiddleware.php
+++ b/app/middleware/AdminMiddleware.php
@@ -28,7 +28,7 @@ use App\Helpers\DBConnection;
 
         $roles = $this->userRepo->getUserRoles($userId);
 
-        if (!in_array('admin', $roles)) {
+        if (!array_intersect(['admin', 'superadmin'], $roles)) {
             http_response_code(403);
             echo "Acceso denegado: No tiene permisos para esta sección.";
             exit;

--- a/app/view/admin/components/sidebar.php
+++ b/app/view/admin/components/sidebar.php
@@ -1,3 +1,8 @@
+<?php
+    use App\Helpers\SessionHelper;
+    SessionHelper::start();
+    $user = SessionHelper::getUser();
+?>
 <!-- Botón hamburguesa -->
 <button class="sidebar-toggle-btn" id="sidebarToggle">
     <i class="fa fa-bars"></i>
@@ -35,9 +40,11 @@
                     <li><a href="/anime-shop/public/admin/newsletters"><i class="fa fa-list"></i> Ver todos</a></li>
                 </ul>
             </li>
-            <li>
-                <a href="/anime-shop/public/admin/setting"><i class="fa fa-cogs"></i> Configuración</a>
-            </li>
+            <?php if(in_array( 'superadmin', $user['roles'])): ?>
+                <li>
+                    <a href="/anime-shop/public/admin/setting"><i class="fa fa-cogs"></i> Configuración</a>
+                </li>
+            <?php endif; ?>
             <li>
                 <a href="/anime-shop/public/user/logout">
                     <i class="fa fa-sign-out-alt"></i> Cerrar sesión

--- a/app/view/user/account.php
+++ b/app/view/user/account.php
@@ -5,7 +5,7 @@
         <h1>Mi cuenta</h1>
         <h2>Información del usuario</h2>
         <div class="account-info">
-            <p><strong>Nombre:</strong> <?php echo ""; //= htmlspecialchars($userDetails['name']) ?></p>
+            <p><strong>Nombre:</strong> <?= htmlspecialchars($userDetails['name']) ?></p>
             <p><strong>Email:</strong> <?= htmlspecialchars($userDetails['email']) ?></p>
             <p><strong>Teléfono:</strong> <?= htmlspecialchars($userDetails['phone'] ?? 'No registrado') ?></p>
         </div>

--- a/app/view/user/register.php
+++ b/app/view/user/register.php
@@ -17,15 +17,6 @@
                 <label for="confirm_password">Confirmar contraseña</label>
                 <input type="password" id="confirm_password" name="confirm_password">
         </div>
-        <!-- Agregado: Campo de selección de rol -->
-        <div class="form-group">
-            <label for="role">Tipo de usuario</label>
-            <select id="role" name="role" required>
-                <option value="">Selecciona un rol</option>
-                <option value="customer">Cliente</option>
-                <option value="admin">Administrador</option>
-            </select>
-        </div>
         <button type="submit" class="btn-primary">Registrarse</button>
         <p>¿Ya tienes una cuenta? <a href="../user/login">Inicia  sesión aquí</a></p>
     </form>

--- a/public/assets/js/components/registerForm.js
+++ b/public/assets/js/components/registerForm.js
@@ -13,7 +13,6 @@ export function initRegisterForm() {
         const email = form.elements['email'].value;
         const password = form.elements['password'].value;
         const confirmPassword = form.elements['confirm_password'].value;
-        const role = form.elements['role'].value;
 
         let errors = [];
 
@@ -36,9 +35,6 @@ export function initRegisterForm() {
             errors.push('La confirmación de la contraseña es obligatoria.');
         else if (!areEqual(password, confirmPassword))
             errors.push('Las contraseñas no coinciden.');
-
-        if (!isNotEmpty(role))
-            errors.push('El rol es obligatorio.');
 
         if (errors.length > 0) {
             showToast(errors.join('\n'), 'error');


### PR DESCRIPTION
```markdown
1. Se removió la opción de selección de rol en el registro de usuarios; ahora todos los registros son automáticamente customer.
2. Se ajustó el controlador de registro para asignar siempre el rol customer.
3. Se dejó intacto el Repository y Modelo de usuario para futuras versiones.
4. Se creó un procedimiento SQL para que el superadmin pueda dar de alta administradores manualmente.
5. Se implementó validación de acceso basada en roles (admin y superadmin) en módulos y vistas.
6. Se corrigió la visualización del nombre del usuario en "Mi cuenta".
```
