### PR TITLE
chore: update .gitignore to ignore local config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,14 @@ Thumbs.db
 
 # --- CONFIGURACIONES LOCALES / SENSIBLES ---
 app/config/database.php
+app/config/mercadopago.php
+app/config/url.config.php
+app/config/recaptcha.php
+storage/user.log
+
+# --- CONFIGURACIÓN DE EMAIL LOCAL / PRODUCCIÓN ---
+app/config/email_production.php
+app/config/email_local.php
 
 # --- CACHE / LOGS ---
 cache/
@@ -29,3 +37,6 @@ logs/
 # --- PHP ---
 # Es como un "ejecutable" en php
 *.phar
+
+# Composer
+/vendor/


### PR DESCRIPTION
# Actualización de .gitignore

Este PR actualiza el archivo .gitignore para excluir los archivos de configuración local y producción:

- app/config/email_local.php
- app/config/email_production.php

Esto asegura que los archivos sensibles no se suban al repositorio.
